### PR TITLE
feat: add disable MX check param

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import emailValidator from 'node-email-verifier';
 // Example with MX record checking
 async function validateEmailWithMx(email) {
   try {
-    const isValid = await emailValidator(email, true);
+    const isValid = await emailValidator(email);
     console.log(`Is "${email}" a valid email address with MX checking?`, isValid);
   } catch (error) {
     console.error('Error validating email with MX checking:', error);

--- a/README.md
+++ b/README.md
@@ -3,16 +3,15 @@
 
 # Node Email Verifier
 
-Node Email Verifier is a email validation library for Node.js that checks if an
-email address has a valid format and verifies the domain's MX (Mail Exchange)
+Node Email Verifier is an email validation library for Node.js that checks if an
+email address has a valid format and optionally verifies the domain's MX (Mail Exchange)
 records to ensure it can receive emails.
 
 ## Features
 
-- **RFC 5322 Format Validation**: Validates email addresses against the standard
-email formatting rules.
-- **MX Record Checking**: Verifies that the domain of the email address has
-valid MX records indicating that it can receive emails.
+- **RFC 5322 Format Validation**: Validates email addresses against the standard email formatting rules.
+- **MX Record Checking**: Verifies that the domain of the email address has valid MX records indicating that it can receive emails. This check can be disabled using a parameter.
+
 
 ## Installation
 
@@ -24,36 +23,49 @@ npm install node-email-verifier --save
 
 ## Usage
 
-Here's a simple example of how to use Node Email Verifier:
+Here's how to use Node Email Verifier, with and without MX record checking:
 
 ```javascript
 import emailValidator from 'node-email-verifier';
 
-async function validateEmail(email) {
+// Example with MX record checking
+async function validateEmailWithMx(email) {
   try {
-    const isValid = await emailValidator(email);
-    console.log(`Is "${email}" a valid email address?`, isValid);
+    const isValid = await emailValidator(email, true);
+    console.log(`Is "${email}" a valid email address with MX checking?`, isValid);
   } catch (error) {
-    console.error('Error validating email:', error);
+    console.error('Error validating email with MX checking:', error);
   }
 }
 
-validateEmail('test@example.com').then();
+// Example without MX record checking
+async function validateEmailWithoutMx(email) {
+  try {
+    const isValid = await emailValidator(email, false);
+    console.log(`Is "${email}" a valid email address without MX checking?`, isValid);
+  } catch (error) {
+    console.error('Error validating email without MX checking:', error);
+  }
+}
+
+validateEmailWithMx('test@example.com').then();
+validateEmailWithoutMx('test@example.com').then();
 ```
 
 ## API
 
-### ```async emailValidator(email)```
+### ```async emailValidator(email, checkMx = true)```
 
-Validates the given email address.
+Validates the given email address, with an option to skip MX record verification.
 
 #### Parameters
 
 - ```email``` (string): The email address to validate.
+- ```checkMx``` (boolean): Whether to check for MX records, this defaults to true.
 
 #### Returns
 
-- ```Promise<boolean>```: A promise that resolves to true if the email address is valid, false otherwise.
+- ```Promise<boolean>```: A promise that resolves to true if the email address is valid and, if checked, has MX records; false otherwise.
 
 ## Contributing
 

--- a/src/index.js
+++ b/src/index.js
@@ -34,17 +34,22 @@ const checkMxRecords = async (email) => {
 
 /**
  * A sophisticated email validator that checks both the format of the email
- * address and the existence of MX records for the domain.
+ * address and the existence of MX records for the domain, depending on the
+ * checkMx parameter.
  * 
  * @param {string} email - The email address to validate.
+ * @param {boolean} checkMx - Determines whether to check for MX records.
+ *  Defaults to true.
  * @return {Promise<boolean>} - Promise that resolves to true if the email is
  *  valid, false otherwise.
  */
-const emailValidator = async (email) => {
+const emailValidator = async (email, checkMx = true) => {
   if (!validateRfc5322(email)) return false;
 
-  const hasMxRecords = await checkMxRecords(email);
-  if (!hasMxRecords) return false;
+  if (checkMx) {
+    const hasMxRecords = await checkMxRecords(email);
+    if (!hasMxRecords) return false;
+  }
 
   return true;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,15 +1,29 @@
 import emailValidator from '../src/index.js';
 
 describe('Email Validator', () => {
-  test('should validate correct email format', async () => {
-    expect(await emailValidator('test@example.com')).toBe(true);
+  // Testing with MX record check enabled
+  describe('with MX record check', () => {
+    test('should validate correct email format and MX record exists', async () => {
+      expect(await emailValidator('test@example.com')).toBe(true);
+    });
+
+    test('should reject email from domain without MX records', async () => {
+      expect(await emailValidator('test@adafwefewsd.com')).toBe(false);
+    });
   });
 
-  test('should reject incorrect email format', async () => {
-    expect(await emailValidator('invalid-email')).toBe(false);
-  });
+  // Testing without MX record check
+  describe('without MX record check', () => {
+    test('should validate correct email format regardless of MX records', async () => {
+      expect(await emailValidator('test@example.com', false)).toBe(true);
+    });
 
-  test('should reject email from domain without MX records', async () => {
-    expect(await emailValidator('test@adafwefewsd.com')).toBe(false);
+    test('should reject incorrect email format regardless of MX records', async () => {
+      expect(await emailValidator('invalid-email', false)).toBe(false);
+    });
+
+    test('should validate email from domain without MX records', async () => {
+      expect(await emailValidator('test@adafwefewsd.com', false)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
This change adds a parameter named `checkMx` to the `emailValidator` function to disable the MX records check if needed. This handy feature can be used during testing or if users don't want the MX validation. The param defaults to `true`, so the change is backward compatible. This feature was requested by @zertex and will close issue #5.