### PR TITLE
fix: resolve dependabot configuration issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # CODEOWNERS file for automatic review requests
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owner for everything in the repo
 * @jesselpalmer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS file for automatic review requests
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo
+* @jesselpalmer
+
+# Specific owners for certain paths (examples - uncomment and modify as needed)
+# /.github/ @jesselpalmer
+# /docs/ @jesselpalmer
+# /src/ @jesselpalmer
+# /test/ @jesselpalmer

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,7 @@ updates:
       day: 'monday'
       time: '04:00'
     open-pull-requests-limit: 10
-    reviewers:
-      - 'jesselpalmer'
+    # Reviewers are now specified in .github/CODEOWNERS
     labels:
       - 'dependencies'
       - 'automated'
@@ -51,8 +50,7 @@ updates:
       interval: 'weekly'
       day: 'monday'
       time: '04:00'
-    reviewers:
-      - 'jesselpalmer'
+    # Reviewers are now specified in .github/CODEOWNERS
     labels:
       - 'dependencies'
       - 'github-actions'


### PR DESCRIPTION
## Summary

This PR fixes the Dependabot configuration issues that are preventing PR #53 from auto-merging.

## Changes

- **Added CODEOWNERS file**: Created `.github/CODEOWNERS` to specify default reviewers, replacing the deprecated `reviewers` field in dependabot.yml
- **Updated dependabot.yml**: Removed the deprecated `reviewers` field as recommended by GitHub
- **Created missing label**: Added the `automated` label that was referenced but missing

## Context

PR #53 (Dependabot's prettier update) was failing to auto-merge due to:
1. Missing `automated` label that was referenced in dependabot.yml
2. Deprecated `reviewers` configuration that GitHub is phasing out
3. The PR being behind main branch

This PR addresses issues 1 and 2. After merging this, we can trigger a rebase on PR #53 to resolve issue 3.

## Test Plan

- [x] Verified CODEOWNERS syntax is correct
- [x] Verified dependabot.yml is valid after removing reviewers field
- [x] Created the `automated` label via GitHub CLI
- [x] All tests pass

## Next Steps

After merging this PR:
1. Comment `@dependabot rebase` on PR #53 to update it with main
2. The auto-merge workflow should then succeed