### PR TITLE
fix: resolve shell command injection vulnerabilities in tests

### DIFF
--- a/test/build-cjs.test.ts
+++ b/test/build-cjs.test.ts
@@ -4,7 +4,7 @@
  * Running this test in isolation without building first will fail.
  */
 import { describe, it, expect } from '@jest/globals';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -15,7 +15,7 @@ describe('Build CJS Script', () => {
 
   it('should create CommonJS wrapper successfully', () => {
     // Run the build script
-    const output = execSync(`node ${scriptPath}`, { encoding: 'utf8' });
+    const output = execFileSync('node', [scriptPath], { encoding: 'utf8' });
 
     // Check output message
     expect(output).toContain('Created CommonJS wrapper at dist/index.cjs');
@@ -43,7 +43,7 @@ describe('Build CJS Script', () => {
       let errorOutput = '';
 
       try {
-        execSync(`node ${scriptPath}`, { encoding: 'utf8', stdio: 'pipe' });
+        execFileSync('node', [scriptPath], { encoding: 'utf8', stdio: 'pipe' });
       } catch (error: any) {
         exitCode = error.status;
         errorOutput =
@@ -71,7 +71,7 @@ describe('Build CJS Script', () => {
     }
 
     // Run the build script
-    execSync(`node ${scriptPath}`, { encoding: 'utf8' });
+    execFileSync('node', [scriptPath], { encoding: 'utf8' });
 
     // Verify dist directory was created
     expect(fs.existsSync(distPath)).toBe(true);


### PR DESCRIPTION
## Summary

This PR addresses three CodeQL security alerts (#1, #2, #3) related to shell command injection vulnerabilities in the test suite.

## Security Issue

The test file `test/build-cjs.test.ts` was using `execSync` with string interpolation to execute shell commands. This could potentially allow command injection if file paths contain special characters like spaces, quotes, or shell metacharacters.

## Solution

- Replaced all `execSync` calls with `execFileSync`
- Pass command arguments as an array instead of string interpolation
- This prevents the shell from interpreting special characters in file paths

## Changes

```diff
- import { execSync } from 'child_process';
+ import { execFileSync } from 'child_process';

- const output = execSync(`node ${scriptPath}`, { encoding: 'utf8' });
+ const output = execFileSync('node', [scriptPath], { encoding: 'utf8' });
```

## Testing

All tests pass with the new implementation. The functionality remains identical, but is now secure against command injection attacks.

## Security Impact

This change ensures that file paths containing special characters (spaces, quotes, semicolons, etc.) cannot be interpreted as shell commands, preventing potential security vulnerabilities.